### PR TITLE
fix typo in wartime loadout

### DIFF
--- a/data/upgrades/configuration.json
+++ b/data/upgrades/configuration.json
@@ -642,7 +642,7 @@
         "ability": "Gain 1 [Torpedo] slot and 1 [Missile] slot. Replace your ship ability with the following:",
         "shipAbility": {
           "name": "Devastating Barrage",
-          "text": "While you perform a [Torpedo] or [Missile] attack, if the defender is in your [Bullseye Arc], your [Critical Hit] results cannont be canceled by [Evade] results."
+          "text": "While you perform a [Torpedo] or [Missile] attack, if the defender is in your [Bullseye Arc], your [Critical Hit] results cannot be canceled by [Evade] results."
         },
         "grants": [
           {


### PR DESCRIPTION
Fixing typo from `cannont` -> `cannot` 

![](https://infinitearenas.com/xw2/images/upgrades/wartimeloadout.png)